### PR TITLE
[#3098] Update 3d viewer buttons

### DIFF
--- a/deemea-mode-3d/src/index.tsx
+++ b/deemea-mode-3d/src/index.tsx
@@ -66,17 +66,11 @@ function modeFactory({ modeConfiguration }) {
       toolbarService.addButtons(toolbarButtons);
       toolbarService.addButtons(segmentationButtons);
       toolbarService.createButtonSection('primary', [
-        'ResetButton',
-        'Length',
-        'RectangleROI',
-        'Angle',
-        'Probe',
-        'CalibrationLine',
-        'WindowLevel',
-        'Pan',
         'Layout',
+        'Pan',
         'Zoom',
         'Reset',
+        'WindowLevel',
       ]);
       toolbarService.createButtonSection('segmentationToolbox', ['BrushTools', 'Shapes']);
     },


### PR DESCRIPTION
PR pour rendre le Viewer 3D + cohérent avec ce qu'on est capable de faire actuellement
On cache les boutons liés aux predictions (le Reset predictions) + les boutons liés aux annotations 2D (axes, rectangles, angle, calibration)
On se focus sur les segmentations :fusée: